### PR TITLE
refactor: [BE] 멤버 멀티테넌시 중복 제거 및 removeMember 버그 수정 (#25)

### DIFF
--- a/core/core-api/src/main/java/com/coffiness/calfit/core/api/controller/v1/InvitationController.java
+++ b/core/core-api/src/main/java/com/coffiness/calfit/core/api/controller/v1/InvitationController.java
@@ -50,7 +50,7 @@ public class InvitationController {
 
     invitationService.acceptInvitation(token);
 
-    memberService.registerMember(invitation.workspaceId(), user.id(), invitation.memberType());
+    memberService.registerMember(user.id(), invitation.memberType());
 
     return ApiResponse.success();
   }

--- a/core/core-api/src/main/java/com/coffiness/calfit/core/api/controller/v1/MemberController.java
+++ b/core/core-api/src/main/java/com/coffiness/calfit/core/api/controller/v1/MemberController.java
@@ -19,8 +19,7 @@ public class MemberController {
 
   @GetMapping("/api/v1/members")
   public ApiResponse<List<MemberResponse>> getMembers() {
-    String workspaceId = TenantContext.getTenantId();
-    List<MemberInfo> members = memberService.getMembers(workspaceId);
+    List<MemberInfo> members = memberService.getMembers();
     return ApiResponse.success(members.stream().map(MemberResponse::from).toList());
   }
 
@@ -42,8 +41,7 @@ public class MemberController {
   @DeleteMapping("/api/v1/members/{memberId}")
   public ApiResponse<?> removeMember(
       @PathVariable Long memberId, @AuthenticationPrincipal SecurityUser securityUser) {
-    String workspaceId = TenantContext.getTenantId();
-    memberService.removeMember(workspaceId, securityUser.userId(), memberId);
+    memberService.removeMember(securityUser.userId(), memberId);
     return ApiResponse.success();
   }
 }

--- a/core/core-api/src/main/java/com/coffiness/calfit/core/api/controller/v1/WorkspaceController.java
+++ b/core/core-api/src/main/java/com/coffiness/calfit/core/api/controller/v1/WorkspaceController.java
@@ -33,7 +33,7 @@ public class WorkspaceController {
 
     TenantContext.setTenantId(workspace.workspaceId());
 
-    memberService.registerMember(workspace.workspaceId(), securityUser.userId(), MemberType.HR);
+    memberService.registerMember(securityUser.userId(), MemberType.HR);
 
     return ApiResponse.success(WorkspaceResponse.from(workspace));
   }

--- a/core/domain-workspace/src/main/java/com/coffiness/calfit/domain/workspace/member/MemberReader.java
+++ b/core/domain-workspace/src/main/java/com/coffiness/calfit/domain/workspace/member/MemberReader.java
@@ -4,19 +4,28 @@ import java.util.List;
 
 public interface MemberReader {
   /**
-   * 멤버 ID로 멤버 정보 조회
+   * userId로 멤버 정보 조회 (현재 워크스페이스 기준)
    *
    * @param workspaceId 워크스페이스 ID
    * @param userId 사용자 ID
-   * @return 멤버 정보 (없으면 null)
+   * @return 멤버 정보
    */
   Member getMember(String workspaceId, Long userId);
 
   /**
-   * @param workspaceId 워크스페이스 ID
-   * @return 멤버 정보 리스트 (없으면 null)
+   * memberId(PK)로 멤버 정보 조회
+   *
+   * @param memberId 멤버 PK
+   * @return 멤버 정보
    */
-  List<Member> getMembers(String workspaceId);
+  Member getMemberById(Long memberId);
+
+  /**
+   * 현재 워크스페이스의 전체 멤버 조회
+   *
+   * @return 멤버 정보 리스트
+   */
+  List<Member> getMembers();
 
   /**
    * 멤버 존재 여부 확인

--- a/core/domain-workspace/src/main/java/com/coffiness/calfit/domain/workspace/member/MemberService.java
+++ b/core/domain-workspace/src/main/java/com/coffiness/calfit/domain/workspace/member/MemberService.java
@@ -22,8 +22,8 @@ public class MemberService {
   private final UserReader userReader;
 
   @Transactional
-  public Member registerMember(String workspaceId, Long userId, MemberType memberType) {
-    return memberStore.save(workspaceId, userId, memberType);
+  public Member registerMember(Long userId, MemberType memberType) {
+    return memberStore.save(userId, memberType);
   }
 
   @Transactional(readOnly = true)
@@ -34,8 +34,8 @@ public class MemberService {
   }
 
   @Transactional(readOnly = true)
-  public List<MemberInfo> getMembers(String workspaceId) {
-    List<Member> members = memberReader.getMembers(workspaceId);
+  public List<MemberInfo> getMembers() {
+    List<Member> members = memberReader.getMembers();
 
     List<Long> userIds = members.stream().map(Member::userId).toList();
     Map<Long, UserInfo> userMap =
@@ -52,9 +52,9 @@ public class MemberService {
   }
 
   @Transactional
-  public void removeMember(String workspaceId, Long userId, Long memberId) {
-    Member member = memberReader.getMember(workspaceId, memberId);
-    if(userId.equals(member.userId())) {
+  public void removeMember(Long userId, Long memberId) {
+    Member member = memberReader.getMemberById(memberId);
+    if (userId.equals(member.userId())) {
       throw new CoreException(ErrorType.VALIDATION_ERROR);
     }
     memberStore.remove(memberId);

--- a/core/domain-workspace/src/main/java/com/coffiness/calfit/domain/workspace/member/MemberStore.java
+++ b/core/domain-workspace/src/main/java/com/coffiness/calfit/domain/workspace/member/MemberStore.java
@@ -5,14 +5,13 @@ import com.coffiness.calfit.core.enums.MemberType;
 public interface MemberStore {
 
   /**
-   * 멤버 저장
+   * 멤버 저장 (TenantContext에 workspaceId가 설정된 상태에서 호출해야 함)
    *
-   * @param workspaceId 워크스페이스ID
    * @param userId 사용자 ID
    * @param memberType 멤버 타입
    * @return Member 리턴
    */
-  Member save(String workspaceId, Long userId, MemberType memberType);
+  Member save(Long userId, MemberType memberType);
 
   /**
    * 멤버 타입 수정

--- a/core/domain-workspace/src/main/java/com/coffiness/calfit/infra/MemberReaderImpl.java
+++ b/core/domain-workspace/src/main/java/com/coffiness/calfit/infra/MemberReaderImpl.java
@@ -5,6 +5,8 @@ import com.coffiness.calfit.domain.workspace.member.Member;
 import com.coffiness.calfit.domain.workspace.member.MemberReader;
 import com.coffiness.calfit.storage.db.core.member.MemberEntity;
 import com.coffiness.calfit.storage.db.core.member.MemberRepository;
+import com.coffiness.calfit.support.error.CoreException;
+import com.coffiness.calfit.support.error.ErrorType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -21,9 +23,16 @@ public class MemberReaderImpl implements MemberReader {
   }
 
   @Override
-  public List<Member> getMembers(String workspaceId) {
-    List<MemberEntity> entities =
-        memberRepository.findByTenantIdAndStatus(workspaceId, EntityStatus.ACTIVE);
+  public Member getMemberById(Long memberId) {
+    return memberRepository
+        .findById(memberId)
+        .map(this::toWorkspaceMember)
+        .orElseThrow(() -> new CoreException(ErrorType.NOT_FOUND));
+  }
+
+  @Override
+  public List<Member> getMembers() {
+    List<MemberEntity> entities = memberRepository.findByStatus(EntityStatus.ACTIVE);
     return entities.stream().map(this::toWorkspaceMember).toList();
   }
 

--- a/core/domain-workspace/src/main/java/com/coffiness/calfit/infra/MemberStoreImpl.java
+++ b/core/domain-workspace/src/main/java/com/coffiness/calfit/infra/MemberStoreImpl.java
@@ -16,11 +16,11 @@ public class MemberStoreImpl implements MemberStore {
   private final MemberRepository memberRepository;
 
   @Override
-  public Member save(String workspaceId, Long userId, MemberType memberType) {
+  public Member save(Long userId, MemberType memberType) {
     MemberEntity entity = MemberEntity.create(userId, memberType);
     MemberEntity saved = memberRepository.save(entity);
 
-    return new Member(saved.getId(), workspaceId, saved.getUserId(), saved.getMemberType());
+    return new Member(saved.getId(), saved.getTenantId(), saved.getUserId(), saved.getMemberType());
   }
 
   @Override

--- a/storage/db-core/src/main/java/com/coffiness/calfit/storage/db/core/member/MemberRepository.java
+++ b/storage/db-core/src/main/java/com/coffiness/calfit/storage/db/core/member/MemberRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<MemberEntity, Long> {
 
-  List<MemberEntity> findByTenantIdAndStatus(String tenantId, EntityStatus status);
+  List<MemberEntity> findByStatus(EntityStatus status);
 
   MemberEntity findByTenantIdAndUserId(String tenantId, Long userId);
 


### PR DESCRIPTION
## 💡 개요
멤버 멀티테넌시 중복 제거 및 removeMember 버그 수정

## 🔗 관련 이슈
Closes #25 

## 📝 작업 상세 내용
- [x] 멤버 멀티테넌시 중복 제거
- [x] removeMember 버그 수정

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 멤버 등록, 조회, 제거 작업의 내부 구조 변경
  * 멤버 관리 API 메서드 시그니처 업데이트
  * 멤버 저장소 및 조회 로직 재구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->