### PR TITLE
bug(BE): 구글 캘린더 연동 매개변수 수정 및 이메일 반환하도록 서비스 계층 String 타입으로 변경 (#46)

### DIFF
--- a/clients/google-calendar/src/main/java/com/coffiness/calfit/api/GoogleOAuthClient.java
+++ b/clients/google-calendar/src/main/java/com/coffiness/calfit/api/GoogleOAuthClient.java
@@ -8,11 +8,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Base64;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class GoogleOAuthClient implements GoogleOAuthPort {
@@ -25,10 +27,7 @@ public class GoogleOAuthClient implements GoogleOAuthPort {
   @Value("${spring.security.oauth2.client.registration.google.client-secret}")
   private String clientSecret;
 
-  @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
-  private String redirectUri;
-
-  public GoogleTokenModel exchangeToken(String authCode) {
+  public GoogleTokenModel exchangeToken(String authCode, String redirectUri) {
 
     MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
     formData.add("code", authCode);

--- a/clients/google-calendar/src/main/java/com/coffiness/calfit/dto/GoogleOAuthResponseDto.java
+++ b/clients/google-calendar/src/main/java/com/coffiness/calfit/dto/GoogleOAuthResponseDto.java
@@ -1,5 +1,9 @@
 package com.coffiness.calfit.dto;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record GoogleOAuthResponseDto(
     String accessToken,
     String refreshToken,

--- a/core/core-api/src/main/java/com/coffiness/calfit/core/api/controller/v1/AnnouncementBoardController.java
+++ b/core/core-api/src/main/java/com/coffiness/calfit/core/api/controller/v1/AnnouncementBoardController.java
@@ -28,13 +28,15 @@ public class AnnouncementBoardController {
       @Valid @RequestBody AnnouncementBoardCreateRequest request) {
     Long userId = (user != null) ? user.userId() : null;
     AnnouncementBoard board =
-        announcementBoardService.create(request.title(), request.content(), request.pinned(), userId);
+        announcementBoardService.create(
+            request.title(), request.content(), request.pinned(), userId);
     return ApiResponse.success(AnnouncementBoardResponse.from(board));
   }
 
   /* 공지사항 조회 */
   @GetMapping
-  public ApiResponse<List<AnnouncementBoardListResponse>> list(@AuthenticationPrincipal SecurityUser user) {
+  public ApiResponse<List<AnnouncementBoardListResponse>> list(
+      @AuthenticationPrincipal SecurityUser user) {
     List<AnnouncementBoard> result = announcementBoardService.list();
     List<AnnouncementBoardListResponse> responses = new java.util.ArrayList<>();
     for (AnnouncementBoard board : result) {
@@ -51,7 +53,8 @@ public class AnnouncementBoardController {
       @Valid @RequestBody AnnouncementBoardUpdateRequest request) {
     Long userId = (user != null) ? user.userId() : null;
     AnnouncementBoard board =
-        announcementBoardService.update(id, request.title(), request.content(), request.pinned(), userId);
+        announcementBoardService.update(
+            id, request.title(), request.content(), request.pinned(), userId);
     return ApiResponse.success(AnnouncementBoardResponse.from(board));
   }
 

--- a/core/core-api/src/main/java/com/coffiness/calfit/core/api/controller/v1/CalendarConnectController.java
+++ b/core/core-api/src/main/java/com/coffiness/calfit/core/api/controller/v1/CalendarConnectController.java
@@ -18,11 +18,13 @@ public class CalendarConnectController {
   private final CalendarConnectService calendarConnectService;
 
   @PostMapping("/api/v1/calendars/google/connect")
-  public ApiResponse<?> connectGoogleCalendar(
+  public ApiResponse<String> connectGoogleCalendar(
       @Valid @RequestBody CalendarConnectRequest request,
       @AuthenticationPrincipal SecurityUser securityUser) {
-    calendarConnectService.connectGoogleCalendar(request.authCode(), securityUser.userId());
+    String googleEmail =
+        calendarConnectService.connectGoogleCalendar(
+            request.authCode(), request.redirectUri(), securityUser.userId());
 
-    return ApiResponse.success();
+    return ApiResponse.success(googleEmail);
   }
 }

--- a/core/core-api/src/test/java/com/coffiness/calfit/api/FixtureConfiguration.java
+++ b/core/core-api/src/test/java/com/coffiness/calfit/api/FixtureConfiguration.java
@@ -1,6 +1,7 @@
 package com.coffiness.calfit.api;
 
 import com.coffiness.calfit.api.fixture.AnnouncementBoardFixture;
+import com.coffiness.calfit.api.fixture.CalendarFixture;
 import com.coffiness.calfit.api.fixture.MeetingRoomFixture;
 import com.coffiness.calfit.api.fixture.MemberFixture;
 import com.coffiness.calfit.api.fixture.UserFixture;

--- a/core/core-api/src/test/java/com/coffiness/calfit/api/calendar/connect/POST_specs.java
+++ b/core/core-api/src/test/java/com/coffiness/calfit/api/calendar/connect/POST_specs.java
@@ -27,11 +27,11 @@ public class POST_specs {
     String token = userFixture.createUserAndGetToken();
     String validAuthCode = "dummy-auth-code";
 
-    given(googleOAuthPort.exchangeToken(validAuthCode))
+    given(googleOAuthPort.exchangeToken(validAuthCode, "http://localhost:5173/auth/callback"))
         .willReturn(new GoogleTokenModel("mock-access", "mock-refresh", 3600, "test@gmail.com"));
 
     // Act
-    ApiResponse<Void> response = calendarFixture.connectGoogleCalendar(token, validAuthCode);
+    ApiResponse<String> response = calendarFixture.connectGoogleCalendar(token, validAuthCode);
 
     // Assert
     assertThat(response.getResult()).isEqualTo(ResultType.SUCCESS);
@@ -45,7 +45,7 @@ public class POST_specs {
     String emptyAuthCode = "";
 
     // Act
-    ApiResponse<Void> response = calendarFixture.connectGoogleCalendar(token, emptyAuthCode);
+    ApiResponse<String> response = calendarFixture.connectGoogleCalendar(token, emptyAuthCode);
 
     // Assert
     assertThat(response.getResult()).isEqualTo(ResultType.ERROR);

--- a/core/core-api/src/test/java/com/coffiness/calfit/api/fixture/CalendarFixture.java
+++ b/core/core-api/src/test/java/com/coffiness/calfit/api/fixture/CalendarFixture.java
@@ -11,9 +11,10 @@ public record CalendarFixture(BaseFixture base) {
     return new CalendarFixture(BaseFixture.create(environment, objectMapper));
   }
 
-  public ApiResponse<Void> connectGoogleCalendar(String token, String authCode) {
-    CalendarConnectRequest request = new CalendarConnectRequest(authCode);
+  public ApiResponse<String> connectGoogleCalendar(String token, String authCode) {
+    CalendarConnectRequest request =
+        new CalendarConnectRequest(authCode, "http://localhost:5173/auth/callback");
 
-    return base.post("/api/v1/calendars/google/connect", request, token, Void.class);
+    return base.post("/api/v1/calendars/google/connect", request, token, String.class);
   }
 }

--- a/core/domain-calendar/src/main/java/com/coffiness/calfit/domain/CalendarConnectService.java
+++ b/core/domain-calendar/src/main/java/com/coffiness/calfit/domain/CalendarConnectService.java
@@ -4,11 +4,10 @@ import com.coffiness.calfit.model.GoogleTokenModel;
 import com.coffiness.calfit.port.GoogleOAuthPort;
 import com.coffiness.calfit.storage.db.core.calendar.ExternalCalendarEntity;
 import com.coffiness.calfit.storage.db.core.calendar.ExternalCalendarRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.time.LocalDateTime;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
 /*
  * 구글 캘린더 연동 서비스 클래스
@@ -21,10 +20,10 @@ public class CalendarConnectService {
   private final GoogleOAuthPort googleOAuthPort;
   private final ExternalCalendarRepository externalCalendarRepository;
 
-  public void connectGoogleCalendar(String authCode, Long userId) {
+  public String connectGoogleCalendar(String authCode, String redirectUri, Long userId) {
 
     // 구글 토큰 발급 및 이메일 추출
-    GoogleTokenModel tokenModel = googleOAuthPort.exchangeToken(authCode);
+    GoogleTokenModel tokenModel = googleOAuthPort.exchangeToken(authCode, redirectUri);
     String googleEmail = tokenModel.email();
 
     // 토큰 만료 시간 계산
@@ -63,5 +62,7 @@ public class CalendarConnectService {
 
       externalCalendarRepository.save(newCalendar);
     }
+
+    return googleEmail;
   }
 }

--- a/core/domain-calendar/src/main/java/com/coffiness/calfit/port/GoogleOAuthPort.java
+++ b/core/domain-calendar/src/main/java/com/coffiness/calfit/port/GoogleOAuthPort.java
@@ -3,5 +3,5 @@ package com.coffiness.calfit.port;
 import com.coffiness.calfit.model.GoogleTokenModel;
 
 public interface GoogleOAuthPort {
-  GoogleTokenModel exchangeToken(String authCode);
+  GoogleTokenModel exchangeToken(String authCode, String redirectUri);
 }

--- a/core/domain-calendar/src/main/java/com/coffiness/calfit/request/CalendarConnectRequest.java
+++ b/core/domain-calendar/src/main/java/com/coffiness/calfit/request/CalendarConnectRequest.java
@@ -2,4 +2,6 @@ package com.coffiness.calfit.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record CalendarConnectRequest(@NotBlank(message = "구글 인가 코드는 필수입니다.") String authCode) {}
+public record CalendarConnectRequest(
+    @NotBlank(message = "구글 인가 코드는 필수입니다.") String authCode,
+    @NotBlank(message = "리다이렉트 URI는 필수입니다.") String redirectUri) {}


### PR DESCRIPTION
## 💡 개요
- 구글 캘린더 연동 오류 해결 및 이메일 반환을 위한 String으로 타입 변경

## 🔗 관련 이슈
Closes #46 

## 📝 작업 상세 내용
- [x] 기존 하드코딩된 백엔드 YAML 설정 대신, 프론트엔드에서 전달받은 동적 redirectUri를 사용하여 토큰을 교환하도록 OAuth 클라이언트 및 서비스 레이어 리팩터링 
- [x] 구글 서버에서 반환하는 데이터 정상 매핑
- [x] 프론트엔드 UI에 연동된 계정 정보를 표시할 수 있도록  이메일 반환 로직 추가 
- [x] 관련 테스트 코드 구조 및 의존성 업데이트

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

## 🙏 리뷰 요청 사항
> 특히 봐줬으면 하는 부분이 있다면 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * Google 캘린더 연결 시 리다이렉트 URL이 필수 매개변수로 추가되었습니다.
  * 캘린더 연결 완료 후 연결된 Google 이메일 주소가 반환됩니다.

* **개선사항**
  * OAuth 클라이언트의 로깅 기능이 강화되었습니다.
  * JSON 응답 형식이 표준화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->