### PR TITLE
fix : [BE] 회의실 예약 조회 및 스케줄러 미적용 에러 수정 (#104)

### DIFF
--- a/core/domain-interview/src/main/java/com/coffiness/calfit/infra/InterviewRepositoryImpl.java
+++ b/core/domain-interview/src/main/java/com/coffiness/calfit/infra/InterviewRepositoryImpl.java
@@ -7,7 +7,6 @@ import com.coffiness.calfit.core.enums.MeetingRoomStatus;
 import com.coffiness.calfit.core.enums.MemberType;
 import com.coffiness.calfit.domain.workspace.member.Member;
 import com.coffiness.calfit.domain.workspace.member.MemberReader;
-import com.coffiness.calfit.storage.db.core.applicant.ApplicantEntity;
 import com.coffiness.calfit.storage.db.core.applicant.ApplicantRepository;
 import com.coffiness.calfit.storage.db.core.calendar.ScheduleEntity;
 import com.coffiness.calfit.storage.db.core.calendar.ScheduleRepository;
@@ -24,7 +23,6 @@ import com.coffiness.calfit.storage.db.core.interview.InterviewScheduleRepositor
 import com.coffiness.calfit.storage.db.core.meetingRoom.MeetingRoomRepository;
 import com.coffiness.calfit.storage.db.core.meetingRoom.MeetingRoomReservationEntity;
 import com.coffiness.calfit.storage.db.core.meetingRoom.MeetingRoomReservationRepository;
-import com.coffiness.calfit.storage.db.core.user.UserEntity;
 import com.coffiness.calfit.storage.db.core.user.UserRepository;
 import com.coffiness.calfit.support.error.CoreException;
 import com.coffiness.calfit.support.error.ErrorType;
@@ -485,9 +483,15 @@ public class InterviewRepositoryImpl implements InterviewRepository {
       return Map.of();
     }
 
-    Map<Long, String> resolved =
-        userRepository.findAllById(interviewerIds).stream()
-            .collect(Collectors.toMap(UserEntity::getId, UserEntity::getName));
+    Map<Long, String> resolved = new HashMap<>();
+    userRepository
+        .findAllById(interviewerIds)
+        .forEach(
+            user -> {
+              if (user.getId() != null && user.getName() != null) {
+                resolved.put(user.getId(), user.getName());
+              }
+            });
 
     List<Long> unresolvedIds =
         interviewerIds.stream()
@@ -500,7 +504,7 @@ public class InterviewRepositoryImpl implements InterviewRepository {
 
     Map<Long, Member> memberMap =
         memberReader.getMembersByIds(unresolvedIds).stream()
-            .collect(Collectors.toMap(Member::id, member -> member));
+            .collect(Collectors.toMap(Member::id, member -> member, (left, right) -> left));
 
     List<Long> userIdsToLookup =
         memberMap.values().stream()
@@ -512,9 +516,15 @@ public class InterviewRepositoryImpl implements InterviewRepository {
       return resolved;
     }
 
-    Map<Long, String> userNameMap =
-        userRepository.findAllById(userIdsToLookup).stream()
-            .collect(Collectors.toMap(UserEntity::getId, UserEntity::getName));
+    Map<Long, String> userNameMap = new HashMap<>();
+    userRepository
+        .findAllById(userIdsToLookup)
+        .forEach(
+            user -> {
+              if (user.getId() != null && user.getName() != null) {
+                userNameMap.put(user.getId(), user.getName());
+              }
+            });
 
     for (Long unresolvedId : unresolvedIds) {
       Member member = memberMap.get(unresolvedId);
@@ -532,9 +542,15 @@ public class InterviewRepositoryImpl implements InterviewRepository {
       return Map.of();
     }
 
-    Map<Long, String> resolved =
-        applicantRepository.findAllByTenantIdAndIdIn(tenantId, applicantIds).stream()
-            .collect(Collectors.toMap(ApplicantEntity::getId, ApplicantEntity::getName));
+    Map<Long, String> resolved = new HashMap<>();
+    applicantRepository
+        .findAllByTenantIdAndIdIn(tenantId, applicantIds)
+        .forEach(
+            applicant -> {
+              if (applicant.getId() != null && applicant.getName() != null) {
+                resolved.put(applicant.getId(), applicant.getName());
+              }
+            });
 
     List<Long> unresolvedIds =
         applicantIds.stream()

--- a/core/domain-meeting-room/src/main/java/com/coffiness/calfit/infra/MeetingRoomReaderImpl.java
+++ b/core/domain-meeting-room/src/main/java/com/coffiness/calfit/infra/MeetingRoomReaderImpl.java
@@ -93,7 +93,6 @@ public class MeetingRoomReaderImpl implements MeetingRoomReader {
   public List<MeetingRoomReservation> getActiveReservations(
       LocalDateTime fromDatetime, LocalDateTime toDatetime) {
     String tenantId = requireTenantId();
-    syncReservationStatuses(tenantId);
     if (fromDatetime == null || toDatetime == null || !fromDatetime.isBefore(toDatetime)) {
       throw new CoreException(ErrorType.VALIDATION_ERROR);
     }


### PR DESCRIPTION
## 💡 개요
회의실 예약 조회 및 스케줄러 미적용 에러 수정

## 🔗 관련 이슈
Closes #104 

## 📝 작업 상세 내용
- [x] 회의실 조회 에러 수정 
- [x] 회의실 예약 에러 수정
- [x] 회의실 스케줄러 적용 에러 수정 

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 인터뷰 데이터 처리 시 null 값으로 인한 오류 가능성 개선
  * 지원자 이름 조회 과정에서 누락된 데이터 처리 안정성 향상

* **성능 개선**
  * 예약 상태 조회 시 불필요한 사전 동기화 제거로 응답 속도 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->