### PR TITLE
fix: [BE] 배포환경에서 회의실 예약 조회 실패 확인 (#162)

### DIFF
--- a/core/core-api/src/main/java/com/coffiness/calfit/core/api/facade/meetingRoom/MeetingRoomReservationFacade.java
+++ b/core/core-api/src/main/java/com/coffiness/calfit/core/api/facade/meetingRoom/MeetingRoomReservationFacade.java
@@ -19,9 +19,11 @@ import com.coffiness.calfit.support.event.DomainEventPublisher;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class MeetingRoomReservationFacade {
@@ -86,24 +88,48 @@ public class MeetingRoomReservationFacade {
 
   @Transactional(readOnly = true)
   public MeetingRoomReservationResponse toResponse(MeetingRoomReservation reservation) {
-    List<Schedule> schedules = scheduleReader.findByReservationId(reservation.id());
-    if (schedules.isEmpty()) {
-      return MeetingRoomReservationResponse.from(reservation);
+    List<Schedule> schedules;
+    try {
+      schedules = scheduleReader.findByReservationId(reservation.id());
+    } catch (RuntimeException exception) {
+      log.warn(
+          "Failed to load schedules for meeting room reservation. reservationId={}, meetingRoomId={}, interviewScheduleId={}",
+          reservation.id(),
+          reservation.meetingRoomId(),
+          reservation.interviewScheduleId(),
+          exception);
+      return MeetingRoomReservationResponse.fromFallback(reservation);
     }
 
-    ScheduleDetailInfo scheduleDetail = scheduleReader.readDetail(schedules.get(0).id());
-    return new MeetingRoomReservationResponse(
-        reservation.id(),
-        reservation.meetingRoomId(),
-        reservation.userId(),
-        reservation.interviewScheduleId(),
-        scheduleDetail.title(),
-        scheduleDetail.description(),
-        scheduleDetail.ownerName(),
-        scheduleDetail.attendees(),
-        reservation.startDatetime(),
-        reservation.endDatetime(),
-        reservation.status());
+    if (schedules.isEmpty()) {
+      return MeetingRoomReservationResponse.fromFallback(reservation);
+    }
+
+    Schedule representativeSchedule = selectRepresentativeSchedule(reservation, schedules);
+    try {
+      ScheduleDetailInfo scheduleDetail = scheduleReader.readDetail(representativeSchedule.id());
+      return new MeetingRoomReservationResponse(
+          reservation.id(),
+          reservation.meetingRoomId(),
+          reservation.userId(),
+          reservation.interviewScheduleId(),
+          scheduleDetail.title(),
+          scheduleDetail.description(),
+          scheduleDetail.ownerName(),
+          scheduleDetail.attendees(),
+          reservation.startDatetime(),
+          reservation.endDatetime(),
+          reservation.status());
+    } catch (RuntimeException exception) {
+      log.warn(
+          "Failed to build meeting room reservation response. reservationId={}, meetingRoomId={}, interviewScheduleId={}, scheduleId={}",
+          reservation.id(),
+          reservation.meetingRoomId(),
+          reservation.interviewScheduleId(),
+          representativeSchedule.id(),
+          exception);
+      return MeetingRoomReservationResponse.fromFallback(reservation);
+    }
   }
 
   @Transactional
@@ -127,5 +153,14 @@ public class MeetingRoomReservationFacade {
       throw new CoreException(ErrorType.VALIDATION_ERROR);
     }
     return tenantId;
+  }
+
+  private Schedule selectRepresentativeSchedule(
+      MeetingRoomReservation reservation, List<Schedule> schedules) {
+    return schedules.stream()
+        .filter(schedule -> schedule.roomId() != null)
+        .filter(schedule -> schedule.roomId().equals(reservation.meetingRoomId()))
+        .findFirst()
+        .orElse(schedules.get(0));
   }
 }

--- a/core/core-api/src/test/java/com/coffiness/calfit/api/meetingRoom/reserve/POST_specs.java
+++ b/core/core-api/src/test/java/com/coffiness/calfit/api/meetingRoom/reserve/POST_specs.java
@@ -18,11 +18,14 @@ import com.coffiness.calfit.api.v1.response.MeetingRoomReservationResponse;
 import com.coffiness.calfit.api.v1.response.MeetingRoomResponse;
 import com.coffiness.calfit.api.v1.response.UserResponse;
 import com.coffiness.calfit.core.enums.CareerType;
+import com.coffiness.calfit.core.enums.EntityStatus;
 import com.coffiness.calfit.core.enums.InterviewRound;
 import com.coffiness.calfit.core.enums.MemberType;
 import com.coffiness.calfit.core.enums.RecruitmentStageType;
 import com.coffiness.calfit.core.support.response.ApiResponse;
 import com.coffiness.calfit.core.support.response.ResultType;
+import com.coffiness.calfit.storage.db.core.calendar.ScheduleEntity;
+import com.coffiness.calfit.storage.db.core.calendar.ScheduleRepository;
 import com.coffiness.calfit.v1.response.ScheduleResponse;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -339,5 +342,47 @@ class POST_specs {
     assertThat(attendeeSchedules.getData())
         .extracting(ScheduleResponse::title)
         .contains("수동 예약 일정");
+  }
+
+  @Test
+  void 연결된_일정이_없어도_회의실_예약_목록_조회는_실패하지_않는다(
+      @Autowired MemberFixture memberFixture,
+      @Autowired MeetingRoomFixture meetingRoomFixture,
+      @Autowired ScheduleRepository scheduleRepository) {
+    MemberFixture.WorkspaceContext context = memberFixture.setupWorkspace();
+    String token = context.hrToken();
+    String tenantId = context.workspaceId();
+
+    Long meetingRoomId =
+        meetingRoomFixture.create(token, tenantId, "복구 테스트 회의실", 1, 6).getData().id();
+
+    LocalDateTime start = LocalDateTime.of(2030, 4, 10, 10, 0);
+    LocalDateTime end = LocalDateTime.of(2030, 4, 10, 11, 0);
+
+    ApiResponse<MeetingRoomReservationResponse> created =
+        meetingRoomFixture.reserve(
+            token, tenantId, meetingRoomId, "복구 테스트 예약", "설명", start, end, List.of());
+
+    assertThat(created.getResult()).isEqualTo(ResultType.SUCCESS);
+
+    List<ScheduleEntity> schedules =
+        scheduleRepository.findAllByReservationIdAndStatus(
+            created.getData().id(), EntityStatus.ACTIVE);
+    assertThat(schedules).isNotEmpty();
+    schedules.forEach(ScheduleEntity::deleted);
+    scheduleRepository.saveAll(schedules);
+
+    ApiResponse<MeetingRoomReservationResponse[]> reservations =
+        meetingRoomFixture.listReservations(token, tenantId, start.minusHours(1), end.plusHours(1));
+
+    assertThat(reservations.getResult()).isEqualTo(ResultType.SUCCESS);
+
+    Optional<MeetingRoomReservationResponse> reservation =
+        List.of(reservations.getData()).stream()
+            .filter(item -> created.getData().id().equals(item.id()))
+            .findFirst();
+
+    assertThat(reservation).isPresent();
+    assertThat(reservation.get().title()).isEqualTo("회의실 예약");
   }
 }

--- a/core/domain-meeting-room/src/main/java/com/coffiness/calfit/api/v1/response/MeetingRoomReservationResponse.java
+++ b/core/domain-meeting-room/src/main/java/com/coffiness/calfit/api/v1/response/MeetingRoomReservationResponse.java
@@ -19,12 +19,17 @@ public record MeetingRoomReservationResponse(
     MeetingRoomStatus status) {
 
   public static MeetingRoomReservationResponse from(MeetingRoomReservation reservation) {
+    return fromFallback(reservation);
+  }
+
+  public static MeetingRoomReservationResponse fromFallback(MeetingRoomReservation reservation) {
+    String fallbackTitle = reservation.interviewScheduleId() != null ? "면접 일정" : "회의실 예약";
     return new MeetingRoomReservationResponse(
         reservation.id(),
         reservation.meetingRoomId(),
         reservation.userId(),
         reservation.interviewScheduleId(),
-        null,
+        fallbackTitle,
         null,
         null,
         List.of(),


### PR DESCRIPTION
## 💡 개요
배포환경에서 회의실 예약 조회 실패 확인

## 🔗 관련 이슈
Closes #162 

## 📝 작업 상세 내용
- [x] 배포환경에서 회의실 예약 조회 실패 확인

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 회의실 예약 조회 시 스케줄이 없는 경우에도 안정적으로 작동하도록 개선
  * 스케줄 로드 실패 시 폴백 메커니즘 추가로 서비스 안정성 향상
  * 예약 정보 응답 처리 로직 강화

* **테스트**
  * 스케줄이 없거나 손상된 상황에서의 예약 조회 동작을 검증하는 테스트 케이스 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->