### PR TITLE
fix: [BE] 배포환경에서 회의실 예약 조회 실패 해결 (#157)

### DIFF
--- a/core/domain-meeting-room/src/main/java/com/coffiness/calfit/infra/MeetingRoomReaderImpl.java
+++ b/core/domain-meeting-room/src/main/java/com/coffiness/calfit/infra/MeetingRoomReaderImpl.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -54,7 +53,6 @@ public class MeetingRoomReaderImpl implements MeetingRoomReader {
   public long countOverlappingReservations(
       Long meetingRoomId, LocalDateTime startDatetime, LocalDateTime endDatetime) {
     String tenantId = requireTenantId();
-    syncReservationStatuses(tenantId);
     return reservationRepository
         .countByTenantIdAndMeetingRoomIdAndReservationStatusInAndStartDatetimeBeforeAndEndDatetimeAfter(
             tenantId,
@@ -68,7 +66,6 @@ public class MeetingRoomReaderImpl implements MeetingRoomReader {
   public long countOverlappingReservationsByUser(
       Long userId, LocalDateTime startDatetime, LocalDateTime endDatetime) {
     String tenantId = requireTenantId();
-    syncReservationStatuses(tenantId);
     return reservationRepository
         .countByTenantIdAndUserIdAndReservationStatusInAndStartDatetimeBeforeAndEndDatetimeAfter(
             tenantId,
@@ -81,7 +78,6 @@ public class MeetingRoomReaderImpl implements MeetingRoomReader {
   @Override
   public MeetingRoomReservation getActiveReservation(Long meetingRoomId, Long reservationId) {
     String tenantId = requireTenantId();
-    syncReservationStatuses(tenantId);
     MeetingRoomReservationEntity entity =
         reservationRepository
             .findByTenantIdAndIdAndMeetingRoomIdAndReservationStatusIn(
@@ -100,7 +96,6 @@ public class MeetingRoomReaderImpl implements MeetingRoomReader {
     if (fromDatetime == null || toDatetime == null || !fromDatetime.isBefore(toDatetime)) {
       throw new CoreException(ErrorType.VALIDATION_ERROR);
     }
-    syncReservationStatuses(tenantId);
 
     List<Long> meetingRoomIds =
         meetingRoomRepository.findAllByStatusOrderByNameAsc(EntityStatus.ACTIVE).stream()
@@ -120,17 +115,6 @@ public class MeetingRoomReaderImpl implements MeetingRoomReader {
         .stream()
         .map(this::toReservation)
         .toList();
-  }
-
-  private void syncReservationStatuses(String tenantId) {
-    LocalDateTime now = LocalDateTime.now();
-    reservationRepository.bulkUpdateToExpired(
-        tenantId,
-        new ArrayList<>(List.of(MeetingRoomStatus.RESERVED, MeetingRoomStatus.ACTIVE)),
-        MeetingRoomStatus.EXPIRED,
-        now);
-    reservationRepository.bulkUpdateToActive(
-        tenantId, MeetingRoomStatus.RESERVED, MeetingRoomStatus.ACTIVE, now);
   }
 
   private MeetingRoom toMeetingRoom(MeetingRoomEntity entity) {


### PR DESCRIPTION
## 💡 개요
배포환경에서 회의실 예약 조회 실패 해결

## 🔗 관련 이슈
Closes #157

## 📝 작업 상세 내용
- [x] 배포환경에서 회의실 예약 조회 실패 원인 파악후 해결

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 회의실 예약 조회 시 상태 동기화 작업을 제거하여 성능을 개선했습니다.
  * 불필요한 코드를 정리하고 예약 상태 관리 프로세스를 단순화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->