### PR TITLE
feat: [BE] 면접관 일정 생성 제한 및 권한 설정 (#167)

### DIFF
--- a/core/domain-interview/src/main/java/com/coffiness/calfit/infra/InterviewValidatorImpl.java
+++ b/core/domain-interview/src/main/java/com/coffiness/calfit/infra/InterviewValidatorImpl.java
@@ -22,7 +22,7 @@ public class InterviewValidatorImpl implements InterviewValidator {
   @Override
   public void validateHrMember(Long userId) {
     if (!interviewReader.isHrMember(userId)) {
-      throw new CoreException(ErrorType.UNAUTHORIZED);
+      throw new CoreException(ErrorType.FORBIDDEN);
     }
   }
 

--- a/support/error/src/main/java/com/coffiness/calfit/support/error/ErrorCode.java
+++ b/support/error/src/main/java/com/coffiness/calfit/support/error/ErrorCode.java
@@ -3,6 +3,7 @@ package com.coffiness.calfit.support.error;
 public enum ErrorCode {
   E400,
   E401,
+  E403,
   E404,
   E500
 }

--- a/support/error/src/main/java/com/coffiness/calfit/support/error/ErrorType.java
+++ b/support/error/src/main/java/com/coffiness/calfit/support/error/ErrorType.java
@@ -7,6 +7,7 @@ public enum ErrorType {
   VALIDATION_ERROR(HttpStatus.BAD_REQUEST, ErrorCode.E400, "Invalid request.", LogLevel.INFO),
   BAD_REQUEST(HttpStatus.BAD_REQUEST, ErrorCode.E400, "Bad request.", LogLevel.INFO),
   UNAUTHORIZED(HttpStatus.UNAUTHORIZED, ErrorCode.E401, "Unauthorized.", LogLevel.INFO),
+  FORBIDDEN(HttpStatus.FORBIDDEN, ErrorCode.E403, "Forbidden.", LogLevel.INFO),
   NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "Resource not found.", LogLevel.INFO),
   DEFAULT_ERROR(
       HttpStatus.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
## 💡 개요
면접관 일정 생성 제한 및 권한 설정

## 🔗 관련 이슈
Closes #167 

## 📝 작업 상세 내용
- [x] 면접관은 일정 생성할 수 없다 

## 📸 스크린샷 (Optional)

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * HR 구성원이 아닌 사용자가 접근을 시도할 때 시스템이 올바른 HTTP 403(금지됨) 상태 코드를 반환합니다. 이전에는 부정확한 오류 응답이 발생했으나, 이제 권한 부족 상황을 정확하게 구분합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->