### PR TITLE
feat(BE): 채용 홈 공고 접근 권한과 주간 면접 조회 범위 보완 (#176)

### DIFF
--- a/core/core-api/src/main/java/com/coffiness/calfit/core/api/facade/recruitment/RecruitmentFacade.java
+++ b/core/core-api/src/main/java/com/coffiness/calfit/core/api/facade/recruitment/RecruitmentFacade.java
@@ -76,8 +76,17 @@ public class RecruitmentFacade {
     LocalDateTime from = normalizedDate.minusDays(daysFromSunday).atStartOfDay();
     LocalDateTime to = from.plusDays(7);
 
-    Long interviewerUserId = member.memberType() == MemberType.HR ? null : userId;
-    return interviewReader.getWeeklySchedules(interviewerUserId, from, to);
+    if (member.memberType() == MemberType.HR) {
+      return interviewReader.getWeeklySchedules(null, from, to);
+    }
+
+    List<Long> accessibleRecruitmentIds =
+        recruitmentReader.readAccessibleRecruitmentIds(userId, member.groupId());
+    if (accessibleRecruitmentIds.isEmpty()) {
+      return List.of();
+    }
+
+    return interviewReader.getWeeklySchedules(accessibleRecruitmentIds, from, to);
   }
 
   public RecruitmentDetailInfo updateRecruitment(

--- a/core/core-api/src/test/java/com/coffiness/calfit/api/recruitment/list/GET_specs.java
+++ b/core/core-api/src/test/java/com/coffiness/calfit/api/recruitment/list/GET_specs.java
@@ -134,11 +134,9 @@ public class GET_specs {
         memberFixture.createGroup("무관 조직", "#F59E0B", hrToken, tenantId).getData().id();
 
     MemberAccessContext leadMember =
-        createWorkspaceMember(
-            memberFixture, userFixture, context, "lead-member", null);
+        createWorkspaceMember(memberFixture, userFixture, context, "lead-member", null);
     MemberAccessContext referenceMember =
-        createWorkspaceMember(
-            memberFixture, userFixture, context, "reference-member", null);
+        createWorkspaceMember(memberFixture, userFixture, context, "reference-member", null);
     MemberAccessContext interviewerMember =
         createWorkspaceMember(
             memberFixture, userFixture, context, "interviewer-member", unrelatedGroupId);
@@ -182,13 +180,11 @@ public class GET_specs {
         .extracting(RecruitmentListResponse::title)
         .contains("접근 범위 확인용 채용");
 
-    assertThat(
-            recruitmentFixture.getRecruitmentList(referenceMember.token(), tenantId).getData())
+    assertThat(recruitmentFixture.getRecruitmentList(referenceMember.token(), tenantId).getData())
         .extracting(RecruitmentListResponse::title)
         .contains("접근 범위 확인용 채용");
 
-    assertThat(
-            recruitmentFixture.getRecruitmentList(interviewerMember.token(), tenantId).getData())
+    assertThat(recruitmentFixture.getRecruitmentList(interviewerMember.token(), tenantId).getData())
         .extracting(RecruitmentListResponse::title)
         .contains("접근 범위 확인용 채용");
 

--- a/core/core-api/src/test/java/com/coffiness/calfit/api/recruitment/weekly/GET_specs.java
+++ b/core/core-api/src/test/java/com/coffiness/calfit/api/recruitment/weekly/GET_specs.java
@@ -405,7 +405,8 @@ class GET_specs {
         memberFixture.createInvitation(
             context.hrToken(), context.workspaceId(), email, MemberType.INTERVIEWER);
     memberFixture.acceptInvitation(invitationResponse.getData().token(), token);
-    MemberResponse memberResponse = memberFixture.getMyMember(token, context.workspaceId()).getData();
+    MemberResponse memberResponse =
+        memberFixture.getMyMember(token, context.workspaceId()).getData();
     return new MemberAccessContext(token, userId, memberResponse.id());
   }
 

--- a/core/domain-interview/src/main/java/com/coffiness/calfit/domain/interview/InterviewReader.java
+++ b/core/domain-interview/src/main/java/com/coffiness/calfit/domain/interview/InterviewReader.java
@@ -24,7 +24,7 @@ public interface InterviewReader {
   // 채용 공고의 면접 단계별 대기 지원자 목록을 조회
   List<PendingInterviewStage> getPendingInterviewStages(Long recruitmentId);
 
-  // 주간 면접 일정 화면에 필요한 인터뷰 목록을 조회
+  // 접근 가능한 채용 공고 기준으로 주간 면접 일정 목록을 조회
   List<WeeklyInterviewScheduleItem> getWeeklySchedules(
-      Long interviewerUserId, LocalDateTime from, LocalDateTime to);
+      List<Long> recruitmentIds, LocalDateTime from, LocalDateTime to);
 }

--- a/core/domain-interview/src/main/java/com/coffiness/calfit/infra/InterviewReaderImpl.java
+++ b/core/domain-interview/src/main/java/com/coffiness/calfit/infra/InterviewReaderImpl.java
@@ -106,8 +106,8 @@ public class InterviewReaderImpl implements InterviewReader {
   // 저장소 조회 결과를 주간 면접 일정 전용 도메인 모델로 변환
   @Override
   public List<WeeklyInterviewScheduleItem> getWeeklySchedules(
-      Long interviewerUserId, LocalDateTime from, LocalDateTime to) {
-    return interviewRepository.getWeeklySchedules(interviewerUserId, from, to).stream()
+      List<Long> recruitmentIds, LocalDateTime from, LocalDateTime to) {
+    return interviewRepository.getWeeklySchedules(recruitmentIds, from, to).stream()
         .map(
             row ->
                 new WeeklyInterviewScheduleItem(

--- a/core/domain-interview/src/main/java/com/coffiness/calfit/infra/InterviewRepositoryImpl.java
+++ b/core/domain-interview/src/main/java/com/coffiness/calfit/infra/InterviewRepositoryImpl.java
@@ -403,38 +403,30 @@ public class InterviewRepositoryImpl implements InterviewRepository {
     return result;
   }
 
-  // 권한 범위에 맞는 이번 주 면접 일정을 조회용 row로 조합
+  // 접근 가능한 채용 공고 기준으로 이번 주 면접 일정을 조회용 row로 조합
   @Override
   public List<WeeklyInterviewScheduleRow> getWeeklySchedules(
-      Long interviewerUserId, LocalDateTime from, LocalDateTime to) {
+      List<Long> recruitmentIds, LocalDateTime from, LocalDateTime to) {
     if (from == null || to == null || !from.isBefore(to)) {
       return List.of();
     }
 
     String tenantId = requireTenantId();
     List<InterviewScheduleEntity> schedules;
-    if (interviewerUserId == null) {
+    if (recruitmentIds == null) {
       schedules =
           interviewScheduleRepository
               .findAllByTenantIdAndScheduledAtGreaterThanEqualAndScheduledAtLessThanAndInterviewStatusNotOrderByScheduledAtAsc(
                   tenantId, from, to, InterviewStatus.CANCELLED);
     } else {
-      List<Long> scheduleIds =
-          interviewerRepository
-              .findAllByTenantIdAndUserIdIn(tenantId, List.of(interviewerUserId))
-              .stream()
-              .map(InterviewScheduleInterviewerEntity::getInterviewScheduleId)
-              .distinct()
-              .toList();
-
-      if (scheduleIds.isEmpty()) {
+      if (recruitmentIds.isEmpty()) {
         return List.of();
       }
 
       schedules =
           interviewScheduleRepository
-              .findAllByTenantIdAndIdInAndScheduledAtGreaterThanEqualAndScheduledAtLessThanAndInterviewStatusNotOrderByScheduledAtAsc(
-                  tenantId, scheduleIds, from, to, InterviewStatus.CANCELLED);
+              .findAllByTenantIdAndRecruitmentIdInAndScheduledAtGreaterThanEqualAndScheduledAtLessThanAndInterviewStatusNotOrderByScheduledAtAsc(
+                  tenantId, recruitmentIds, from, to, InterviewStatus.CANCELLED);
     }
 
     if (schedules.isEmpty()) {
@@ -473,9 +465,9 @@ public class InterviewRepositoryImpl implements InterviewRepository {
             .toList();
     Map<Long, String> applicantNameMap = resolveApplicantNameMap(tenantId, applicantIds);
 
-    List<Long> recruitmentIds =
+    List<Long> scheduleRecruitmentIds =
         schedules.stream().map(InterviewScheduleEntity::getRecruitmentId).distinct().toList();
-    Map<Long, String> recruitmentTitleMap = resolveRecruitmentTitleMap(recruitmentIds);
+    Map<Long, String> recruitmentTitleMap = resolveRecruitmentTitleMap(scheduleRecruitmentIds);
 
     List<Long> recruitmentStageIds =
         schedules.stream()

--- a/core/domain-recruitment/src/main/java/com/coffiness/calfit/domain/recruitment/RecruitmentReader.java
+++ b/core/domain-recruitment/src/main/java/com/coffiness/calfit/domain/recruitment/RecruitmentReader.java
@@ -9,7 +9,15 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RecruitmentReader {
 
-  List<RecruitmentListInfo> readList(RecruitmentStatus recruitmentStatus, Pageable pageable);
+  List<RecruitmentListInfo> readList(
+      Long userId,
+      Long groupId,
+      boolean hrMember,
+      RecruitmentStatus recruitmentStatus,
+      Pageable pageable);
+
+  // 목록/주간 면접 권한 판별에 사용할 접근 가능 공고 ID를 조회
+  List<Long> readAccessibleRecruitmentIds(Long userId, Long groupId);
 
   RecruitmentDetailInfo readDetail(Long recruitmentId);
 

--- a/core/domain-recruitment/src/main/java/com/coffiness/calfit/domain/recruitment/RecruitmentService.java
+++ b/core/domain-recruitment/src/main/java/com/coffiness/calfit/domain/recruitment/RecruitmentService.java
@@ -3,9 +3,13 @@ package com.coffiness.calfit.domain.recruitment;
 import com.coffiness.calfit.api.v1.request.RecruitmentCreateRequest;
 import com.coffiness.calfit.api.v1.request.RecruitmentStageRequest;
 import com.coffiness.calfit.api.v1.request.RecruitmentUpdateRequest;
+import com.coffiness.calfit.core.enums.MemberType;
 import com.coffiness.calfit.core.enums.RecruitmentActionType;
 import com.coffiness.calfit.core.enums.RecruitmentStageType;
 import com.coffiness.calfit.core.enums.RecruitmentStatus;
+import com.coffiness.calfit.domain.workspace.member.Member;
+import com.coffiness.calfit.domain.workspace.member.MemberReader;
+import com.coffiness.calfit.storage.db.core.config.TenantContext;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -24,6 +28,7 @@ public class RecruitmentService {
   private final RecruitmentStore recruitmentStore;
   private final RecruitmentHistoryAppender recruitmentHistoryAppender;
   private final RecruitmentReader recruitmentReader;
+  private final MemberReader memberReader;
 
   public Long createRecruitment(long userId, RecruitmentCreateRequest request) {
 
@@ -68,8 +73,13 @@ public class RecruitmentService {
   @Transactional(readOnly = true)
   public List<RecruitmentListInfo> getRecruitmentList(
       long userId, RecruitmentStatus recruitmentStatus, Pageable pageable) {
-
-    return recruitmentReader.readList(recruitmentStatus, pageable);
+    Member member = getRequiredMember(userId);
+    return recruitmentReader.readList(
+        userId,
+        member.groupId(),
+        member.memberType() == MemberType.HR,
+        recruitmentStatus,
+        pageable);
   }
 
   @Transactional(readOnly = true)
@@ -227,6 +237,12 @@ public class RecruitmentService {
           "면접관 설정 수정",
           afterRecruitment);
     }
+  }
+
+  // 현재 워크스페이스 기준으로 목록 조회에 사용할 멤버 정보를 가져옴
+  private Member getRequiredMember(long userId) {
+    String workspaceId = TenantContext.getTenantId();
+    return memberReader.getMember(workspaceId, userId);
   }
 
   private RecruitmentStatus resolveStatusAtCreation(

--- a/core/domain-recruitment/src/main/java/com/coffiness/calfit/infra/RecruitmentReaderImpl.java
+++ b/core/domain-recruitment/src/main/java/com/coffiness/calfit/infra/RecruitmentReaderImpl.java
@@ -44,16 +44,16 @@ public class RecruitmentReaderImpl implements RecruitmentReader {
 
   @Override
   public List<RecruitmentListInfo> readList(
-      RecruitmentStatus recruitmentStatus, Pageable pageable) {
-    Page<RecruitmentEntity> recruitments;
-
-    if (recruitmentStatus == null) {
-      recruitments = recruitmentRepository.findByStatus(EntityStatus.ACTIVE, pageable);
-    } else {
-      recruitments =
-          recruitmentRepository.findByRecruitmentStatusAndStatus(
-              recruitmentStatus, EntityStatus.ACTIVE, pageable);
-    }
+      Long userId,
+      Long groupId,
+      boolean hrMember,
+      RecruitmentStatus recruitmentStatus,
+      Pageable pageable) {
+    Page<RecruitmentEntity> recruitments =
+        hrMember
+            ? readAllRecruitments(recruitmentStatus, pageable)
+            : recruitmentRepository.findAccessibleByUserIdAndGroupIdAndStatus(
+                userId, groupId, recruitmentStatus, EntityStatus.ACTIVE, pageable);
 
     if (recruitments.isEmpty()) {
       return List.of();
@@ -138,9 +138,10 @@ public class RecruitmentReaderImpl implements RecruitmentReader {
                   interviewerMap.getOrDefault(recruitmentId, List.of()).stream()
                       .map(
                           i -> {
-                            Long userId = i.getUserId();
-                            String name = userNameMap.getOrDefault(userId, "알 수 없는 사용자");
-                            return new RecruitmentListInfo.AssigneeSummaryInfo(userId, name);
+                            Long interviewerUserId = i.getUserId();
+                            String name = userNameMap.getOrDefault(interviewerUserId, "알 수 없는 사용자");
+                            return new RecruitmentListInfo.AssigneeSummaryInfo(
+                                interviewerUserId, name);
                           })
                       .toList();
 
@@ -160,6 +161,22 @@ public class RecruitmentReaderImpl implements RecruitmentReader {
                   assigneeInfos);
             })
         .toList();
+  }
+
+  @Override
+  public List<Long> readAccessibleRecruitmentIds(Long userId, Long groupId) {
+    return recruitmentRepository.findAccessibleIdsByUserIdAndGroupIdAndStatus(
+        userId, groupId, EntityStatus.ACTIVE);
+  }
+
+  // HR 목록 조회는 기존처럼 워크스페이스 전체 채용 공고를 반환한다.
+  private Page<RecruitmentEntity> readAllRecruitments(
+      RecruitmentStatus recruitmentStatus, Pageable pageable) {
+    if (recruitmentStatus == null) {
+      return recruitmentRepository.findByStatus(EntityStatus.ACTIVE, pageable);
+    }
+    return recruitmentRepository.findByRecruitmentStatusAndStatus(
+        recruitmentStatus, EntityStatus.ACTIVE, pageable);
   }
 
   // 목록 화면용 단계 정보를 만들고 최종 합격 단계를 항상 마지막에 보정

--- a/storage/db-core/src/main/java/com/coffiness/calfit/storage/db/core/interview/InterviewRepository.java
+++ b/storage/db-core/src/main/java/com/coffiness/calfit/storage/db/core/interview/InterviewRepository.java
@@ -67,9 +67,9 @@ public interface InterviewRepository {
   // 채용 공고의 면접 단계별 대기 지원자 목록을 조회
   List<PendingInterviewStageRow> getPendingInterviewStages(Long recruitmentId);
 
-  // 주간 면접 일정 화면용 인터뷰 목록을 조회
+  // 접근 가능한 채용 공고 기준으로 주간 면접 일정 목록을 조회
   List<WeeklyInterviewScheduleRow> getWeeklySchedules(
-      Long interviewerUserId, LocalDateTime from, LocalDateTime to);
+      List<Long> recruitmentIds, LocalDateTime from, LocalDateTime to);
 
   Long createConfirmedSchedule(
       Long userId,

--- a/storage/db-core/src/main/java/com/coffiness/calfit/storage/db/core/interview/InterviewScheduleRepository.java
+++ b/storage/db-core/src/main/java/com/coffiness/calfit/storage/db/core/interview/InterviewScheduleRepository.java
@@ -59,6 +59,22 @@ public interface InterviewScheduleRepository extends JpaRepository<InterviewSche
   @Query(
       "SELECT e FROM InterviewScheduleEntity e "
           + "WHERE e.tenantId = :tenantId "
+          + "AND e.recruitmentId IN :recruitmentIds "
+          + "AND e.scheduledAt >= :from "
+          + "AND e.scheduledAt < :to "
+          + "AND e.interviewStatus <> :status "
+          + "ORDER BY e.scheduledAt ASC")
+  List<InterviewScheduleEntity>
+      findAllByTenantIdAndRecruitmentIdInAndScheduledAtGreaterThanEqualAndScheduledAtLessThanAndInterviewStatusNotOrderByScheduledAtAsc(
+          @Param("tenantId") String tenantId,
+          @Param("recruitmentIds") List<Long> recruitmentIds,
+          @Param("from") LocalDateTime from,
+          @Param("to") LocalDateTime to,
+          @Param("status") InterviewStatus status);
+
+  @Query(
+      "SELECT e FROM InterviewScheduleEntity e "
+          + "WHERE e.tenantId = :tenantId "
           + "AND e.id IN :ids "
           + "AND e.scheduledAt >= :from "
           + "AND e.scheduledAt < :to "

--- a/storage/db-core/src/main/java/com/coffiness/calfit/storage/db/core/recruitment/RecruitmentRepository.java
+++ b/storage/db-core/src/main/java/com/coffiness/calfit/storage/db/core/recruitment/RecruitmentRepository.java
@@ -22,6 +22,93 @@ public interface RecruitmentRepository extends JpaRepository<RecruitmentEntity, 
   Page<RecruitmentEntity> findByRecruitmentStatusAndStatus(
       RecruitmentStatus recruitmentStatus, EntityStatus status, Pageable pageable);
 
+  @Query(
+      """
+      SELECT r.id
+      FROM RecruitmentEntity r
+      WHERE r.status = :entityStatus
+        AND (
+          (:groupId IS NOT NULL AND r.leadGroupId = :groupId)
+          OR EXISTS (
+            SELECT 1
+            FROM RecruitmentInterviewerEntity ri
+            WHERE ri.recruitmentId = r.id
+              AND ri.userId = :userId
+          )
+          OR (
+            :groupId IS NOT NULL
+            AND EXISTS (
+              SELECT 1
+              FROM RecruitmentReferenceGroupEntity rg
+              WHERE rg.recruitmentId = r.id
+                AND rg.groupId = :groupId
+            )
+          )
+        )
+      """)
+  List<Long> findAccessibleIdsByUserIdAndGroupIdAndStatus(
+      @Param("userId") Long userId,
+      @Param("groupId") Long groupId,
+      @Param("entityStatus") EntityStatus entityStatus);
+
+  @Query(
+      value =
+          """
+          SELECT r
+          FROM RecruitmentEntity r
+          WHERE r.status = :entityStatus
+            AND (:recruitmentStatus IS NULL OR r.recruitmentStatus = :recruitmentStatus)
+            AND (
+              (:groupId IS NOT NULL AND r.leadGroupId = :groupId)
+              OR EXISTS (
+                SELECT 1
+                FROM RecruitmentInterviewerEntity ri
+                WHERE ri.recruitmentId = r.id
+                  AND ri.userId = :userId
+              )
+              OR (
+                :groupId IS NOT NULL
+                AND EXISTS (
+                  SELECT 1
+                  FROM RecruitmentReferenceGroupEntity rg
+                  WHERE rg.recruitmentId = r.id
+                    AND rg.groupId = :groupId
+                )
+              )
+            )
+          """,
+      countQuery =
+          """
+          SELECT COUNT(r)
+          FROM RecruitmentEntity r
+          WHERE r.status = :entityStatus
+            AND (:recruitmentStatus IS NULL OR r.recruitmentStatus = :recruitmentStatus)
+            AND (
+              (:groupId IS NOT NULL AND r.leadGroupId = :groupId)
+              OR EXISTS (
+                SELECT 1
+                FROM RecruitmentInterviewerEntity ri
+                WHERE ri.recruitmentId = r.id
+                  AND ri.userId = :userId
+              )
+              OR (
+                :groupId IS NOT NULL
+                AND EXISTS (
+                  SELECT 1
+                  FROM RecruitmentReferenceGroupEntity rg
+                  WHERE rg.recruitmentId = r.id
+                    AND rg.groupId = :groupId
+                )
+              )
+            )
+          """)
+  Page<RecruitmentEntity> findAccessibleByUserIdAndGroupIdAndStatus(
+      @Param("userId") Long userId,
+      @Param("groupId") Long groupId,
+      @Param("recruitmentStatus") RecruitmentStatus recruitmentStatus,
+      @Param("entityStatus") EntityStatus entityStatus,
+      Pageable pageable);
+
   Optional<RecruitmentEntity> findByIdAndStatus(Long id, EntityStatus status);
 
   @Modifying(clearAutomatically = true, flushAutomatically = true)


### PR DESCRIPTION
## 💡 개요
채용 홈에서 채용 공고 목록과 이번 주 면접 예정이 사용자 권한에 맞게 조회되도록 백엔드 접근 정책을 정리하였으며, 인사담당자는 기존처럼 워크스페이스의 모든 채용 공고를 볼 수 있고, 일반 멤버는 담당 조직, 참조 조직, 등록 면접관으로 연결된 공고만 조회할 수 있도록 설정함.
또한 이번 주 면접 예정도 동일한 공고 접근 권한 기준으로 집계되도록 보완함.

## 🔗 관련 이슈
Closes #176

## 📝 작업 상세 내용
- [x] 채용 공고 목록 조회에서 HR은 전체 공고를, 일반 멤버는 접근 가능한 공고만 조회하도록 권한 정책 수정
- [x] 이번 주 면접 예정 조회도 동일한 공고 접근 권한 기준으로 계산되도록 백엔드 로직 보완
- [x] 목록 조회/주간 면접 조회 권한 회귀 테스트를 추가해 HR 전체 조회와 권한 없는 멤버 0건 케이스 검증

## 👀 체크리스트
- [x] 커밋 메시지 컨벤션을 지켰나요?
- [x] 로컬에서 테스트는 모두 통과했나요?
- [x] 불필요한 공백이나 주석은 제거했나요?
- [x] 팀원들이 이해하기 쉽도록 주석을 적절히 달았나요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **새 기능**
  - 채용공고 목록 조회 시 사용자의 역할에 따른 접근 제어가 적용됩니다.
  - 담당조직원, 참조조직원, 등록면접관은 관련된 채용공고를 조회할 수 있습니다.
  - 이번 주 면접 일정 조회가 접근 권한이 있는 채용공고로만 필터링됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->